### PR TITLE
Fix #10: correct Character class name in AutoDataOutputStream.writeValue()

### DIFF
--- a/src/main/java/com/github/exabrial/redexsm/io/AutoDataOutputStream.java
+++ b/src/main/java/com/github/exabrial/redexsm/io/AutoDataOutputStream.java
@@ -35,7 +35,7 @@ public class AutoDataOutputStream extends DataOutputStream {
 				super.writeByte((byte) value);
 				yield 'B';
 			}
-			case "java.lang.Char" -> {
+			case "java.lang.Character" -> {
 				super.writeChar((char) value);
 				yield 'C';
 			}


### PR DESCRIPTION
Fix #10: correct Character class name in AutoDataOutputStream.writeValue()

The switch case used "java.lang.Char" which is not a valid class name. The correct name is "java.lang.Character". This caused Character values to always fall through to the default branch and throw IllegalArgumentException.