### PR TITLE
Fix #14: default ignorePattern to match-nothing to prevent NPE

### DIFF
--- a/src/main/java/com/github/exabrial/redexsm/ImprovedRedisSessionManager.java
+++ b/src/main/java/com/github/exabrial/redexsm/ImprovedRedisSessionManager.java
@@ -51,7 +51,7 @@ public class ImprovedRedisSessionManager extends ManagerBase implements SessionR
 
 	protected String keyPassword;
 	protected String redisUrl;
-	protected Pattern ignorePattern;
+	protected Pattern ignorePattern = Pattern.compile("(?!.*)");
 	protected String keyPrefix;
 	protected String nodeId;
 	protected String sessionCookieName;


### PR DESCRIPTION
Fix #14: default ignorePattern to match-nothing to prevent NPE\n\nThe `ignorePattern` field was null when the user omitted it from `context.xml`, causing an NPE on every request in `requestComplete()`. The field now defaults to `Pattern.compile("(?!.*)")` so replication always fires when unconfigured.
