### PR TITLE
Fix #11: replace reflective field access with direct access in ImprovedRedisSession

### DIFF
--- a/src/main/java/com/github/exabrial/redexsm/ImprovedRedisSession.java
+++ b/src/main/java/com/github/exabrial/redexsm/ImprovedRedisSession.java
@@ -15,7 +15,6 @@
  */
 package com.github.exabrial.redexsm;
 
-import java.lang.reflect.Field;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -39,15 +38,9 @@ public class ImprovedRedisSession extends StandardSession {
 
 	protected Map<String, Object> attributeMap;
 
-	@SuppressWarnings("unchecked")
 	protected ImprovedRedisSession(final ImprovedRedisSessionManager manager) {
 		super(manager);
-		try {
-			final Field attributeMapField = StandardSession.class.getDeclaredField("attributes");
-			attributeMap = (Map<String, Object>) attributeMapField.get(this);
-		} catch (final Exception e) {
-			throw new RuntimeException(e);
-		}
+		attributeMap = this.attributes;
 	}
 
 	protected Map<String, Object> getAttributeMap() {


### PR DESCRIPTION
Fix #11: replace reflective field access with direct access in ImprovedRedisSession

Since ImprovedRedisSession extends StandardSession, the protected field attributes is directly accessible. The reflective access via getDeclaredField() was unnecessary and fragile.